### PR TITLE
Fix validation checks for AddDish form

### DIFF
--- a/src/pages/AddDish.js
+++ b/src/pages/AddDish.js
@@ -56,7 +56,7 @@ const AddDish = () => {
         if (data?.restaurante?.id === null ||
             formData?.nome === null ||
             formData?.preco === null ||
-            formData?.preco === null ||
+            formData?.descricao === null ||
             formData?.imagem === null
         ) {
             setToastMessage(
@@ -117,7 +117,7 @@ const AddDish = () => {
         if (data?.restaurante?.id === null ||
             formData?.nome === null ||
             formData?.preco === null ||
-            formData?.preco === null ||
+            formData?.descricao === null ||
             formData?.imagem === null
         ) {
             setToastMessage(


### PR DESCRIPTION
## Summary
- correct validation conditions for dish form to include description

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e0c67dc8331823b2829430cabb8